### PR TITLE
Add basic layout with sidebar navigation

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -1,0 +1,90 @@
+/* Estilos base para el dashboard Cubo */
+
+:root {
+    --sidebar-width: 200px;
+    --sidebar-collapsed-width: 60px;
+    --bg-color: #ffffff;
+    --sidebar-bg: #f5f5f5;
+    --sidebar-active: #e0e0e0;
+    --text-color: #333333;
+    --transition-speed: 0.3s;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    display: flex;
+    font-family: Arial, Helvetica, sans-serif;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    min-height: 100vh;
+}
+
+.sidebar {
+    width: var(--sidebar-width);
+    background-color: var(--sidebar-bg);
+    transition: width var(--transition-speed);
+    overflow: hidden;
+}
+
+.sidebar.collapsed {
+    width: var(--sidebar-collapsed-width);
+}
+
+.toggle-btn {
+    width: 100%;
+    padding: 10px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 20px;
+}
+
+.menu {
+    list-style: none;
+}
+
+.menu li a {
+    display: flex;
+    align-items: center;
+    padding: 10px;
+    text-decoration: none;
+    color: var(--text-color);
+    transition: background-color var(--transition-speed);
+}
+
+.menu li a:hover,
+.menu li a.active {
+    background-color: var(--sidebar-active);
+}
+
+.menu li a .label {
+    margin-left: 10px;
+}
+
+.sidebar.collapsed .label {
+    display: none;
+}
+
+.content {
+    flex-grow: 1;
+    padding: 20px;
+}
+
+@media (max-width: 600px) {
+    .sidebar {
+        position: fixed;
+        height: 100%;
+        z-index: 1000;
+    }
+    .content {
+        margin-left: var(--sidebar-width);
+    }
+    .sidebar.collapsed + .content {
+        margin-left: var(--sidebar-collapsed-width);
+    }
+}

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -1,0 +1,56 @@
+// Funciones para el dashboard Cubo
+
+/**
+ * Carga el contenido de una sección dentro del elemento main.
+ * @param {string} section Nombre de la sección (archivo HTML)
+ */
+function loadSection(section) {
+    const container = document.getElementById('content');
+    fetch(`app/views/${section}.html`)
+        .then(response => response.text())
+        .then(html => {
+            container.innerHTML = html;
+        })
+        .catch(() => {
+            container.innerHTML = '<p>No se pudo cargar la sección.</p>';
+        });
+}
+
+/**
+ * Marca el enlace activo en el menú lateral.
+ * @param {HTMLElement} element Enlace que fue clicado
+ */
+function setActive(element) {
+    document.querySelectorAll('.menu a').forEach(a => a.classList.remove('active'));
+    element.classList.add('active');
+}
+
+/**
+ * Alterna la clase 'collapsed' en el sidebar para ocultar o mostrar el menú.
+ */
+function toggleSidebar() {
+    document.getElementById('sidebar').classList.toggle('collapsed');
+}
+
+// Inicializar eventos una vez que el DOM esté listo
+window.addEventListener('DOMContentLoaded', () => {
+    // Manejar clic en el botón de colapso
+    document.getElementById('toggleSidebar').addEventListener('click', toggleSidebar);
+
+    // Manejar clic en los ítems del menú
+    document.querySelectorAll('.menu a').forEach(link => {
+        link.addEventListener('click', event => {
+            event.preventDefault();
+            const section = link.getAttribute('data-section');
+            setActive(link);
+            loadSection(section);
+        });
+    });
+
+    // Cargar la sección inicial
+    const first = document.querySelector('.menu a');
+    if (first) {
+        const section = first.getAttribute('data-section');
+        loadSection(section);
+    }
+});

--- a/app/views/alertas.html
+++ b/app/views/alertas.html
@@ -1,0 +1,2 @@
+<h2>Alertas</h2>
+<p>Contenido de ejemplo para la sección Alertas.</p>

--- a/app/views/canales.html
+++ b/app/views/canales.html
@@ -1,0 +1,2 @@
+<h2>Canales</h2>
+<p>Contenido de ejemplo para la sección Canales.</p>

--- a/app/views/cartera_castigada.html
+++ b/app/views/cartera_castigada.html
@@ -1,0 +1,2 @@
+<h2>Cartera Castigada</h2>
+<p>Contenido de ejemplo para la sección Cartera Castigada.</p>

--- a/app/views/cartera_vigente.html
+++ b/app/views/cartera_vigente.html
@@ -1,0 +1,2 @@
+<h2>Cartera Vigente</h2>
+<p>Contenido de ejemplo para la sección Cartera Vigente.</p>

--- a/app/views/cierre_de_junta.html
+++ b/app/views/cierre_de_junta.html
@@ -1,0 +1,2 @@
+<h2>Cierre de Junta</h2>
+<p>Contenido de ejemplo para la sección Cierre de Junta.</p>

--- a/app/views/embudo.html
+++ b/app/views/embudo.html
@@ -1,0 +1,2 @@
+<h2>Embudo</h2>
+<p>Contenido de ejemplo para la sección Embudo.</p>

--- a/app/views/historico.html
+++ b/app/views/historico.html
@@ -1,0 +1,2 @@
+<h2>Histórico</h2>
+<p>Contenido de ejemplo para la sección Histórico.</p>

--- a/app/views/saldos.html
+++ b/app/views/saldos.html
@@ -1,0 +1,2 @@
+<h2>Saldos</h2>
+<p>Contenido de ejemplo para la sección Saldos.</p>

--- a/app/views/tacticos.html
+++ b/app/views/tacticos.html
@@ -1,0 +1,2 @@
+<h2>Tácticos</h2>
+<p>Contenido de ejemplo para la sección Tácticos.</p>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cubo Dashboard</title>
+    <link rel="stylesheet" href="app/css/style.css">
+</head>
+<body>
+    <nav id="sidebar" class="sidebar">
+        <button id="toggleSidebar" class="toggle-btn">☰</button>
+        <ul class="menu">
+            <li><a href="#" data-section="alertas" class="active">📢 <span class="label">Alertas</span></a></li>
+            <li><a href="#" data-section="saldos">💰 <span class="label">Saldos</span></a></li>
+            <li><a href="#" data-section="embudo">📊 <span class="label">Embudo</span></a></li>
+            <li><a href="#" data-section="canales">🔗 <span class="label">Canales</span></a></li>
+            <li><a href="#" data-section="cartera_vigente">📂 <span class="label">Cartera Vigente</span></a></li>
+            <li><a href="#" data-section="cartera_castigada">🗂️ <span class="label">Cartera Castigada</span></a></li>
+            <li><a href="#" data-section="tacticos">📈 <span class="label">Tácticos</span></a></li>
+            <li><a href="#" data-section="historico">📜 <span class="label">Histórico</span></a></li>
+            <li><a href="#" data-section="cierre_de_junta">✔️ <span class="label">Cierre de Junta</span></a></li>
+        </ul>
+    </nav>
+    <main id="content" class="content">
+        <!-- El contenido de las secciones se cargará aquí -->
+    </main>
+    <script src="app/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create base index.html with sidebar menu
- add simple sidebar and layout styles
- implement dynamic section loading with vanilla JS
- stub out view html files for each section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68780c46d78c8320a13d8d134b855357