### PR TITLE
Implement leader alert management

### DIFF
--- a/app/js/auth/leaderSession.js
+++ b/app/js/auth/leaderSession.js
@@ -1,0 +1,19 @@
+import { LEADERS } from "../constants.js";
+
+const STORAGE_KEY = "cubo_current_leader";
+
+export function getCurrentLeader() {
+  return localStorage.getItem(STORAGE_KEY) || null;
+}
+
+export function setCurrentLeader(name) {
+  if (LEADERS.includes(name)) {
+    localStorage.setItem(STORAGE_KEY, name);
+    return true;
+  }
+  return false;
+}
+
+export function clearCurrentLeader() {
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/app/js/constants.js
+++ b/app/js/constants.js
@@ -1,0 +1,12 @@
+export const LEADERS = ["Tatiana", "Adriana", "Lina", "Juan"];
+export const SECCIONES = [
+  "Alertas",
+  "Saldos",
+  "Embudo",
+  "Canales",
+  "Cartera Vigente",
+  "Cartera Castigada",
+  "Tácticos",
+  "Histórico",
+  "Cierre de Junta",
+];

--- a/app/js/modules/alertManager.js
+++ b/app/js/modules/alertManager.js
@@ -1,0 +1,61 @@
+import { sanitize } from "../utils/sanitize.js";
+
+const STORAGE_KEY = "cubo_alerts";
+
+function loadAll() {
+  try {
+    const data = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    return data && typeof data === "object" ? data : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveAll(data) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+export function getAlertsByAuthor(author) {
+  const data = loadAll();
+  return data[author] ? [...data[author]] : [];
+}
+
+export function addAlert(message, author) {
+  const data = loadAll();
+  const alerts = data[author] || [];
+  const newAlert = {
+    id: Date.now().toString(),
+    mensaje: sanitize(message),
+    autor: author,
+    fecha: new Date().toISOString(),
+  };
+  alerts.push(newAlert);
+  data[author] = alerts;
+  saveAll(data);
+  return newAlert;
+}
+
+export function updateAlert(id, message, author) {
+  const data = loadAll();
+  const alerts = data[author] || [];
+  const alerta = alerts.find((a) => a.id === id);
+  if (!alerta || alerta.autor !== author) {
+    return false;
+  }
+  alerta.mensaje = sanitize(message);
+  saveAll(data);
+  return true;
+}
+
+export function deleteAlert(id, author) {
+  const data = loadAll();
+  const alerts = data[author] || [];
+  const index = alerts.findIndex((a) => a.id === id);
+  if (index === -1) {
+    return false;
+  }
+  alerts.splice(index, 1);
+  data[author] = alerts;
+  saveAll(data);
+  return true;
+}

--- a/app/js/utils/sanitize.js
+++ b/app/js/utils/sanitize.js
@@ -1,0 +1,12 @@
+export function sanitize(str) {
+  return str.replace(/[&<>"'`]/g, (c) => {
+    return {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;',
+      '`': '&#96;'
+    }[c];
+  });
+}

--- a/app/js/views/LeaderAlertas.js
+++ b/app/js/views/LeaderAlertas.js
@@ -1,0 +1,127 @@
+import { getCurrentLeader, setCurrentLeader } from "../auth/leaderSession.js";
+import { LEADERS } from "../constants.js";
+import { addAlert, getAlertsByAuthor, updateAlert, deleteAlert } from "../modules/alertManager.js";
+
+function showAuthModal() {
+  const modal = document.getElementById("leader-auth-modal");
+  if (!modal) return;
+  modal.style.display = "flex";
+}
+
+function hideAuthModal() {
+  const modal = document.getElementById("leader-auth-modal");
+  if (!modal) return;
+  modal.style.display = "none";
+}
+
+function setupAuth() {
+  const btn = document.getElementById("leaderAuthBtn");
+  if (!btn) return;
+  btn.addEventListener("click", () => {
+    const input = document.getElementById("leaderNameInput");
+    const name = (input.value || "").trim();
+    if (!LEADERS.includes(name)) {
+      alert("Nombre de líder no válido");
+      return;
+    }
+    setCurrentLeader(name);
+    hideAuthModal();
+    renderAlertSection();
+  });
+}
+
+function createAlertElement(alerta, leader) {
+  const item = document.createElement("div");
+  const text = document.createElement("p");
+  text.innerHTML = alerta.mensaje;
+  const info = document.createElement("small");
+  info.textContent = new Date(alerta.fecha).toLocaleString();
+  const editBtn = document.createElement("button");
+  editBtn.textContent = "Editar";
+  const delBtn = document.createElement("button");
+  delBtn.textContent = "Eliminar";
+
+  editBtn.addEventListener("click", () => {
+    let nuevo = prompt("Editar alerta", alerta.mensaje);
+    if (nuevo === null) return;
+    if (!nuevo.trim()) {
+      alert("El mensaje no puede estar vacío");
+      return;
+    }
+    updateAlert(alerta.id, nuevo, leader);
+    renderAlertsList();
+  });
+
+  delBtn.addEventListener("click", () => {
+    deleteAlert(alerta.id, leader);
+    renderAlertsList();
+  });
+
+  item.appendChild(text);
+  item.appendChild(info);
+  item.appendChild(editBtn);
+  item.appendChild(delBtn);
+  return item;
+}
+
+function renderAlertsList() {
+  const leader = getCurrentLeader();
+  const list = document.getElementById("alertList");
+  if (!leader || !list) return;
+  const datos = getAlertsByAuthor(leader);
+  list.innerHTML = "";
+  datos.forEach((a) => list.appendChild(createAlertElement(a, leader)));
+}
+
+function renderAlertSection() {
+  const container = document.getElementById("content");
+  if (!container) return;
+  const leader = getCurrentLeader();
+  if (!leader) {
+    showAuthModal();
+    return;
+  }
+  container.innerHTML = `
+    <section class="dashboard-section" id="leader-alerts-section">
+      <h2>Mis Alertas</h2>
+      <div id="alertList"></div>
+      <form id="alertForm">
+        <div>Autor: <span id="alertAuthor">${leader}</span></div>
+        <textarea id="alertMessage" style="width:100%;height:60px;"></textarea>
+        <button type="submit">Agregar</button>
+      </form>
+    </section>
+  `;
+  document.getElementById("alertForm").addEventListener("submit", (e) => {
+    e.preventDefault();
+    const msgInput = document.getElementById("alertMessage");
+    const mensaje = msgInput.value.trim();
+    if (!mensaje) {
+      alert("El mensaje no puede estar vacío");
+      return;
+    }
+    addAlert(mensaje, leader);
+    msgInput.value = "";
+    renderAlertsList();
+  });
+  renderAlertsList();
+}
+
+function checkSectionLoad() {
+  const cont = document.getElementById("content");
+  if (!cont) return;
+  const h2 = cont.querySelector("h2");
+  if (h2 && h2.textContent.trim() === "Alertas" && !document.getElementById("leader-alerts-section")) {
+    renderAlertSection();
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  setupAuth();
+  const target = document.getElementById("content");
+  if (target) {
+    const observer = new MutationObserver(checkSectionLoad);
+    observer.observe(target, { childList: true, subtree: true });
+  }
+  checkSectionLoad();
+});

--- a/index.html
+++ b/index.html
@@ -24,6 +24,20 @@
     <main id="content" class="content">
         <!-- El contenido de las secciones se cargará aquí -->
     </main>
+    <div id="leader-auth-modal" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.4);align-items:center;justify-content:center;">
+        <div style="background:#fff;padding:20px;max-width:300px;width:90%;">
+            <label for="leaderNameInput">Nombre de líder:</label>
+            <input id="leaderNameInput" list="leader-list" style="width:100%;margin-top:5px;" />
+            <datalist id="leader-list">
+                <option value="Tatiana"></option>
+                <option value="Adriana"></option>
+                <option value="Lina"></option>
+                <option value="Juan"></option>
+            </datalist>
+            <button id="leaderAuthBtn" style="margin-top:10px;">Ingresar</button>
+        </div>
+    </div>
+    <script type="module" src="app/js/views/LeaderAlertas.js"></script>
     <script src="app/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add constants for leaders and sections
- implement leader session handling
- create alert manager module with sanitization and author validation
- render leader-specific alert view with authentication modal
- add sanitize helper
- add leader auth modal to `index.html`
- remove unused alerts.js file

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6878201ce46083209ed80bb2cf21ffff