### PR TITLE
Improve offline functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# cubo
-cubo 
+# Cubo
+
+Aplicación web offline para consulta de indicadores y creación de alertas locales.
+
+## Uso
+
+1. Abre `index.html` directamente en tu navegador (sin servidor). Toda la navegación
+   funciona sin conexión.
+2. Utiliza el menú lateral para cambiar de sección.
+3. Los líderes pueden registrar alertas en la sección **Alertas** ingresando su
+   nombre. Las alertas se guardan en `localStorage` del navegador.
+
+## Actualización de datos
+
+Los analistas pueden editar los archivos dentro de `app/data/js/` para
+modificar las respuestas que ofrece cada sección. Cada archivo exporta un array
+con pares `clave` y `respuesta`.
+
+Las imágenes se encuentran en la carpeta `app/images/` y pueden reemplazarse
+libremente manteniendo los mismos nombres.

--- a/app/data/js/respuestas_alertas.js
+++ b/app/data/js/respuestas_alertas.js
@@ -1,0 +1,4 @@
+export default [
+  { "clave": "ventas", "respuesta": "Las ventas aumentaron un 15% respecto al mes anterior." },
+  { "clave": "objetivo", "respuesta": "El objetivo del trimestre fue superado en un 20%." }
+]

--- a/app/data/js/respuestas_canales.js
+++ b/app/data/js/respuestas_canales.js
@@ -1,0 +1,4 @@
+export default [
+  { "clave": "ventas", "respuesta": "Las ventas aumentaron un 15% respecto al mes anterior." },
+  { "clave": "objetivo", "respuesta": "El objetivo del trimestre fue superado en un 20%." }
+]

--- a/app/data/js/respuestas_cartera_castigada.js
+++ b/app/data/js/respuestas_cartera_castigada.js
@@ -1,0 +1,4 @@
+export default [
+  { "clave": "ventas", "respuesta": "Las ventas aumentaron un 15% respecto al mes anterior." },
+  { "clave": "objetivo", "respuesta": "El objetivo del trimestre fue superado en un 20%." }
+]

--- a/app/data/js/respuestas_cartera_vigente.js
+++ b/app/data/js/respuestas_cartera_vigente.js
@@ -1,0 +1,4 @@
+export default [
+  { "clave": "ventas", "respuesta": "Las ventas aumentaron un 15% respecto al mes anterior." },
+  { "clave": "objetivo", "respuesta": "El objetivo del trimestre fue superado en un 20%." }
+]

--- a/app/data/js/respuestas_cierre_de_junta.js
+++ b/app/data/js/respuestas_cierre_de_junta.js
@@ -1,0 +1,4 @@
+export default [
+  { "clave": "ventas", "respuesta": "Las ventas aumentaron un 15% respecto al mes anterior." },
+  { "clave": "objetivo", "respuesta": "El objetivo del trimestre fue superado en un 20%." }
+]

--- a/app/data/js/respuestas_embudo.js
+++ b/app/data/js/respuestas_embudo.js
@@ -1,0 +1,4 @@
+export default [
+  { "clave": "ventas", "respuesta": "Las ventas aumentaron un 15% respecto al mes anterior." },
+  { "clave": "objetivo", "respuesta": "El objetivo del trimestre fue superado en un 20%." }
+]

--- a/app/data/js/respuestas_historico.js
+++ b/app/data/js/respuestas_historico.js
@@ -1,0 +1,4 @@
+export default [
+  { "clave": "ventas", "respuesta": "Las ventas aumentaron un 15% respecto al mes anterior." },
+  { "clave": "objetivo", "respuesta": "El objetivo del trimestre fue superado en un 20%." }
+]

--- a/app/data/js/respuestas_saldos.js
+++ b/app/data/js/respuestas_saldos.js
@@ -1,0 +1,4 @@
+export default [
+  { "clave": "ventas", "respuesta": "Las ventas aumentaron un 15% respecto al mes anterior." },
+  { "clave": "objetivo", "respuesta": "El objetivo del trimestre fue superado en un 20%." }
+]

--- a/app/data/js/respuestas_tacticos.js
+++ b/app/data/js/respuestas_tacticos.js
@@ -1,0 +1,4 @@
+export default [
+  { "clave": "ventas", "respuesta": "Las ventas aumentaron un 15% respecto al mes anterior." },
+  { "clave": "objetivo", "respuesta": "El objetivo del trimestre fue superado en un 20%." }
+]

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -1,19 +1,39 @@
+import { renderAlertas } from "./views/alertasView.js";
+import { renderSaldos } from "./views/saldosView.js";
+import { renderEmbudo } from "./views/embudoView.js";
+import { renderCanales } from "./views/canalesView.js";
+import { renderCarteraVigente } from "./views/carteraVigenteView.js";
+import { renderCarteraCastigada } from "./views/carteraCastigadaView.js";
+import { renderTacticos } from "./views/tacticosView.js";
+import { renderHistorico } from "./views/historicoView.js";
+import { renderCierreJunta } from "./views/cierreJuntaView.js";
+
 // Funciones para el dashboard Cubo
 
 /**
  * Carga el contenido de una sección dentro del elemento main.
  * @param {string} section Nombre de la sección (archivo HTML)
  */
+const VIEW_MAP = {
+    alertas: renderAlertas,
+    saldos: renderSaldos,
+    embudo: renderEmbudo,
+    canales: renderCanales,
+    cartera_vigente: renderCarteraVigente,
+    cartera_castigada: renderCarteraCastigada,
+    tacticos: renderTacticos,
+    historico: renderHistorico,
+    cierre_de_junta: renderCierreJunta,
+};
+
 function loadSection(section) {
     const container = document.getElementById('content');
-    fetch(`app/views/${section}.html`)
-        .then(response => response.text())
-        .then(html => {
-            container.innerHTML = html;
-        })
-        .catch(() => {
-            container.innerHTML = '<p>No se pudo cargar la sección.</p>';
-        });
+    const render = VIEW_MAP[section];
+    if (render) {
+        container.innerHTML = render();
+    } else {
+        container.innerHTML = '<p>No se pudo cargar la sección.</p>';
+    }
 }
 
 /**

--- a/app/js/modules/alertManager.js
+++ b/app/js/modules/alertManager.js
@@ -1,18 +1,14 @@
 import { sanitize } from "../utils/sanitize.js";
+import { readJSON, writeJSON } from "../utils/storageUtil.js";
 
 const STORAGE_KEY = "cubo_alerts";
 
 function loadAll() {
-  try {
-    const data = JSON.parse(localStorage.getItem(STORAGE_KEY));
-    return data && typeof data === "object" ? data : {};
-  } catch {
-    return {};
-  }
+  return readJSON(STORAGE_KEY) || {};
 }
 
 function saveAll(data) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  writeJSON(STORAGE_KEY, data);
 }
 
 export function getAlertsByAuthor(author) {

--- a/app/js/qna.js
+++ b/app/js/qna.js
@@ -1,22 +1,37 @@
+import alertasData from "../data/js/respuestas_alertas.js";
+import saldosData from "../data/js/respuestas_saldos.js";
+import embudoData from "../data/js/respuestas_embudo.js";
+import canalesData from "../data/js/respuestas_canales.js";
+import carteraVigenteData from "../data/js/respuestas_cartera_vigente.js";
+import carteraCastigadaData from "../data/js/respuestas_cartera_castigada.js";
+import tacticosData from "../data/js/respuestas_tacticos.js";
+import historicoData from "../data/js/respuestas_historico.js";
+import cierreData from "../data/js/respuestas_cierre_de_junta.js";
+
 export const FALLBACK =
-  "No encontr\u00e9 datos para tu b\u00fasqueda actual. \u00bfQuieres revisar el informe general del \u00e1rea? \nAbrir informe general. O contacta directamente a Carlos Mart\u00ednez, creador del informe.";
+  "No encontr\u00e9 datos para tu b\u00fasqueda actual. \u00bfQuieres revisar el" +
+  " informe general del \u00e1rea? \nAbrir informe general. O contacta directamente" +
+  " a Carlos Mart\u00ednez, creador del informe.";
+
+const RESPUESTAS = {
+  alertas: alertasData,
+  saldos: saldosData,
+  embudo: embudoData,
+  canales: canalesData,
+  cartera_vigente: carteraVigenteData,
+  cartera_castigada: carteraCastigadaData,
+  tacticos: tacticosData,
+  historico: historicoData,
+  cierre_de_junta: cierreData,
+};
 
 export async function buscarRespuesta(seccion, pregunta) {
-  try {
-    const resp = await fetch(`app/data/respuestas_${seccion}.json`);
-    if (!resp.ok) {
-      return FALLBACK;
+  const datos = RESPUESTAS[seccion] || [];
+  const texto = (pregunta || "").toLowerCase();
+  for (const par of datos) {
+    if (texto.includes(par.clave.toLowerCase())) {
+      return par.respuesta;
     }
-    const datos = await resp.json();
-    const texto = (pregunta || "").toLowerCase();
-    for (const par of datos) {
-      if (texto.includes(par.clave.toLowerCase())) {
-        return par.respuesta;
-      }
-    }
-    return FALLBACK;
-  } catch (e) {
-    return FALLBACK;
   }
+  return FALLBACK;
 }
-

--- a/app/js/utils/storageUtil.js
+++ b/app/js/utils/storageUtil.js
@@ -1,0 +1,12 @@
+export function readJSON(key) {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeJSON(key, data) {
+  localStorage.setItem(key, JSON.stringify(data));
+}

--- a/index.html
+++ b/index.html
@@ -39,6 +39,6 @@
     </div>
     <script type="module" src="app/js/views/LeaderAlertas.js"></script>
     <script type="module" src="app/js/alerts.js"></script>
-    <script src="app/js/main.js"></script>
+    <script type="module" src="app/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add documentation for offline usage and data updates
- load sections with JS modules instead of fetching HTML
- embed question/answer data as JS for offline access
- centralize localStorage helpers
- update alert manager to use storage utils

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68782f2bdcc08320a26e2474fb8977f6