### PR TITLE
Add Tailwind sidebar markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,21 +5,103 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Cubo Dashboard</title>
     <link rel="stylesheet" href="app/css/style.css">
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>
-    <nav id="sidebar" class="sidebar">
-        <button id="toggleSidebar" class="toggle-btn">☰</button>
-        <ul class="menu">
-            <li><a href="#" data-section="alertas" class="active">📢 <span class="label">Alertas</span></a></li>
-            <li><a href="#" data-section="saldos">💰 <span class="label">Saldos</span></a></li>
-            <li><a href="#" data-section="embudo">📊 <span class="label">Embudo</span></a></li>
-            <li><a href="#" data-section="canales">🔗 <span class="label">Canales</span></a></li>
-            <li><a href="#" data-section="cartera_vigente">📂 <span class="label">Cartera Vigente</span></a></li>
-            <li><a href="#" data-section="cartera_castigada">🗂️ <span class="label">Cartera Castigada</span></a></li>
-            <li><a href="#" data-section="tacticos">📈 <span class="label">Tácticos</span></a></li>
-            <li><a href="#" data-section="historico">📜 <span class="label">Histórico</span></a></li>
-            <li><a href="#" data-section="cierre_de_junta">✔️ <span class="label">Cierre de Junta</span></a></li>
+    <nav id="sidebar" class="sidebar bg-white shadow-md flex flex-col">
+        <div class="flex items-center justify-between p-4">
+            <div class="pr-2">
+                <img src="app/images/imagen_logo_indice.png" alt="Logo" class="h-8">
+            </div>
+            <button id="toggleSidebar" class="toggle-btn text-[#505050]">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+            </button>
+        </div>
+        <ul class="menu flex-1">
+            <li>
+                <a href="#" data-section="alertas" class="flex items-center px-4 py-2 text-gray-600 hover:bg-gray-100 active">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-[#505050]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                      <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd"/>
+                    </svg>
+                    <span class="label ml-3">Alertas</span>
+                </a>
+            </li>
+            <li>
+                <a href="#" data-section="saldos" class="flex items-center px-4 py-2 text-gray-600 hover:bg-gray-100">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-[#505050]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                      <path d="M10.75 10.818v2.614A3.13 3.13 0 0011.888 13c.482-.315.612-.648.612-.875 0-.227-.13-.56-.612-.875a3.13 3.13 0 00-1.138-.432zM8.33 8.62c.053.055.115.11.184.164.208.16.46.284.736.363V6.603a2.45 2.45 0 00-.35.13c-.14.065-.27.143-.386.233-.377.292-.514.627-.514.909 0 .184.058.39.202.592.037.051.08.102.128.152z"/>
+                      <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-6a.75.75 0 01.75.75v.316a3.78 3.78 0 011.653.713c.426.33.744.74.925 1.2a.75.75 0 01-1.395.55 1.35 1.35 0 00-.447-.563 2.187 2.187 0 00-.736-.363V9.3c.698.093 1.383.32 1.959.696.787.514 1.29 1.27 1.29 2.13 0 .86-.504 1.616-1.29 2.13-.576.377-1.261.603-1.96.696v.299a.75.75 0 11-1.5 0v-.3c-.697-.092-1.382-.318-1.958-.695-.482-.315-.857-.717-1.078-1.188a.75.75 0 111.359-.636c.08.173.245.376.54.569.313.205.706.353 1.138.432v-2.748a3.782 3.782 0 01-1.653-.713C6.9 9.433 6.5 8.681 6.5 7.875c0-.805.4-1.558 1.097-2.096a3.78 3.78 0 011.653-.713V4.75A.75.75 0 0110 4z" clip-rule="evenodd"/>
+                    </svg>
+                    <span class="label ml-3">Saldos</span>
+                </a>
+            </li>
+            <li>
+                <a href="#" data-section="embudo" class="flex items-center px-4 py-2 text-gray-600 hover:bg-gray-100">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-[#505050]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                      <path fill-rule="evenodd" d="M2.628 1.601C5.028 1.206 7.49 1 10 1s4.973.206 7.372.601a.75.75 0 01.628.74v2.288a2.25 2.25 0 01-.659 1.59l-4.682 4.683a2.25 2.25 0 00-.659 1.59v3.037c0 .684-.31 1.33-.844 1.757l-1.937 1.55A.75.75 0 018 18.25v-5.757a2.25 2.25 0 00-.659-1.591L2.659 6.22A2.25 2.25 0 012 4.629V2.34a.75.75 0 01.628-.74z" clip-rule="evenodd"/>
+                    </svg>
+                    <span class="label ml-3">Embudo</span>
+                </a>
+            </li>
+            <li>
+                <a href="#" data-section="canales" class="flex items-center px-4 py-2 text-gray-600 hover:bg-gray-100">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-[#505050]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                      <path d="M13 4.5a2.5 2.5 0 11.702 1.737L6.973 9.604a2.518 2.518 0 010 .792l6.729 3.367a2.5 2.5 0 11-.671 1.341l-6.733-3.367a2.5 2.5 0 110-3.475l6.733-3.366A2.5 2.5 0 0113 4.5z"/>
+                    </svg>
+                    <span class="label ml-3">Canales</span>
+                </a>
+            </li>
+            <li>
+                <a href="#" data-section="cartera_vigente" class="flex items-center px-4 py-2 text-gray-600 hover:bg-gray-100">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-[#505050]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                      <path fill-rule="evenodd" d="M6 3.75A2.75 2.75 0 018.75 1h2.5A2.75 2.75 0 0114 3.75v.443c.572.055 1.14.122 1.706.2C17.053 4.582 18 5.75 18 7.07v3.469c0 1.126-.694 2.191-1.83 2.54-1.952.599-4.024.921-6.17.921s-4.219-.322-6.17-.921C2.694 12.73 2 11.665 2 10.539V7.07c0-1.321.947-2.489 2.294-2.676A41.047 41.047 0 016 4.193V3.75zm6.5 0v.325a41.622 41.622 0 00-5 0V3.75c0-.69.56-1.25 1.25-1.25h2.5c.69 0 1.25.56 1.25 1.25zM10 10a1 1 0 00-1 1v.01a1 1 0 001 1h.01a1 1 0 001-1V11a1 1 0 00-1-1H10z" clip-rule="evenodd"/>
+                      <path d="M3 15.055v-.684c.126.053.255.1.39.142 2.092.642 4.313.987 6.61.987 2.297 0 4.518-.345 6.61-.987.135-.041.264-.089.39-.142v.684c0 1.347-.985 2.53-2.363 2.686a41.454 41.454 0 01-9.274 0C3.985 17.585 3 16.402 3 15.055z"/>
+                    </svg>
+                    <span class="label ml-3">Cartera Vigente</span>
+                </a>
+            </li>
+            <li>
+                <a href="#" data-section="cartera_castigada" class="flex items-center px-4 py-2 text-gray-600 hover:bg-gray-100">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-[#505050]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                      <path fill-rule="evenodd" d="M5.965 4.904l9.131 9.131a6.5 6.5 0 00-9.131-9.131zm8.07 10.192L4.904 5.965a6.5 6.5 0 009.131 9.131zM4.343 4.343a8 8 0 1111.314 11.314A8 8 0 014.343 4.343z" clip-rule="evenodd"/>
+                    </svg>
+                    <span class="label ml-3">Cartera Castigada</span>
+                </a>
+            </li>
+            <li>
+                <a href="#" data-section="tacticos" class="flex items-center px-4 py-2 text-gray-600 hover:bg-gray-100">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-[#505050]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                      <path d="M12 4.467c0-.405.262-.75.559-1.027.276-.257.441-.584.441-.94 0-.828-.895-1.5-2-1.5s-2 .672-2 1.5c0 .362.171.694.456.953.29.265.544.6.544.994a.968.968 0 01-1.024.974 39.655 39.655 0 01-3.014-.306.75.75 0 00-.847.847c.14.993.242 1.999.306 3.014A.968.968 0 014.447 10c-.393 0-.729-.253-.994-.544C3.194 9.17 2.862 9 2.5 9 1.672 9 1 9.895 1 11s.672 2 1.5 2c.356 0 .683-.165.94-.441.276-.297.622-.559 1.027-.559a.997.997 0 011.004 1.03 39.747 39.747 0 01-.319 3.734.75.75 0 00.64.842c1.05.146 2.111.252 3.184.318A.97.97 0 0010 16.948c0-.394-.254-.73-.545-.995C9.171 15.693 9 15.362 9 15c0-.828.895-1.5 2-1.5s2 .672 2 1.5c0 .356-.165.683-.441.94-.297.276-.559.622-.559 1.027a.998.998 0 001.03 1.005c1.337-.05 2.659-.162 3.961-.337a.75.75 0 00.644-.644c.175-1.302.288-2.624.337-3.961A.998.998 0 0016.967 12c-.405 0-.75.262-1.027.559-.257.276-.584.441-.94.441-.828 0-1.5-.895-1.5-2s.672-2 1.5-2c.362 0 .694.17.953.455.265.291.601.545.995.545a.97.97 0 00.976-1.024 41.159 41.159 0 00-.318-3.184.75.75 0 00-.842-.64c-1.228.164-2.473.271-3.734.319A.997.997 0 0112 4.467z"/>
+                    </svg>
+                    <span class="label ml-3">Tácticos</span>
+                </a>
+            </li>
+            <li>
+                <a href="#" data-section="historico" class="flex items-center px-4 py-2 text-gray-600 hover:bg-gray-100">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-[#505050]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                      <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-13a.75.75 0 00-1.5 0v5c0 .414.336.75.75.75h4a.75.75 0 000-1.5h-3.25V5z" clip-rule="evenodd"/>
+                    </svg>
+                    <span class="label ml-3">Histórico</span>
+                </a>
+            </li>
+            <li>
+                <a href="#" data-section="cierre_de_junta" class="flex items-center px-4 py-2 text-gray-600 hover:bg-gray-100">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-[#505050]" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                      <path d="M11 6H14L17.29 2.7A1 1 0 0 1 18.71 2.7L21.29 5.29A1 1 0 0 1 21.29 6.7L19 9H11V11A1 1 0 0 1 10 12A1 1 0 0 1 9 11V8A2 2 0 0 1 11 6M5 11V15L2.71 17.29A1 1 0 0 0 2.71 18.7L5.29 21.29A1 1 0 0 0 6.71 21.29L11 17H15A1 1 0 0 0 16 16V15H17A1 1 0 0 0 18 14V13H19A1 1 0 0 0 20 12V11H13V12A2 2 0 0 1 11 14H9A2 2 0 0 1 7 12V9Z" />
+                    </svg>
+                    <span class="label ml-3">Cierre de Juntas</span>
+                </a>
+            </li>
         </ul>
+        <button class="flex items-center border border-red-500 text-red-500 rounded-md px-4 py-2 m-4">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mr-2" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M3 4.25A2.25 2.25 0 015.25 2h5.5A2.25 2.25 0 0113 4.25v2a.75.75 0 01-1.5 0v-2a.75.75 0 00-.75-.75h-5.5a.75.75 0 00-.75.75v11.5c0 .414.336.75.75.75h5.5a.75.75 0 00.75-.75v-2a.75.75 0 011.5 0v2A2.25 2.25 0 0110.75 18h-5.5A2.25 2.25 0 013 15.75V4.25z" clip-rule="evenodd"/>
+              <path fill-rule="evenodd" d="M19 10a.75.75 0 00-.75-.75H8.704l1.048-.943a.75.75 0 10-1.004-1.114l-2.5 2.25a.75.75 0 000 1.114l2.5 2.25a.75.75 0 101.004-1.114l-1.048-.943h9.546A.75.75 0 0019 10z" clip-rule="evenodd"/>
+            </svg>
+            <span>Cerrar Sesión</span>
+        </button>
     </nav>
     <main id="content" class="content">
         <!-- El contenido de las secciones se cargará aquí -->


### PR DESCRIPTION
## Summary
- redesign sidebar using Tailwind utility classes
- include inline SVG icons for each menu item
- add logout button with arrow icon
- load Tailwind from CDN

## Testing
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_6879a1aa1b3c832087cce8f1efdd283c