### PR TITLE
Fix sidebar collapse text visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,9 @@
     <nav id="sidebar" class="sidebar bg-white shadow-md flex flex-col">
         <div class="flex items-center justify-between p-4">
             <div class="pr-2">
-                <img src="app/images/imagen_logo_indice.png" alt="Logo" class="h-8">
+                <span class="label">
+                    <img src="app/images/imagen_logo_indice.png" alt="Logo" class="h-8">
+                </span>
             </div>
             <button id="toggleSidebar" class="toggle-btn text-[#505050]">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -100,7 +102,7 @@
               <path fill-rule="evenodd" d="M3 4.25A2.25 2.25 0 015.25 2h5.5A2.25 2.25 0 0113 4.25v2a.75.75 0 01-1.5 0v-2a.75.75 0 00-.75-.75h-5.5a.75.75 0 00-.75.75v11.5c0 .414.336.75.75.75h5.5a.75.75 0 00.75-.75v-2a.75.75 0 011.5 0v2A2.25 2.25 0 0110.75 18h-5.5A2.25 2.25 0 013 15.75V4.25z" clip-rule="evenodd"/>
               <path fill-rule="evenodd" d="M19 10a.75.75 0 00-.75-.75H8.704l1.048-.943a.75.75 0 10-1.004-1.114l-2.5 2.25a.75.75 0 000 1.114l2.5 2.25a.75.75 0 101.004-1.114l-1.048-.943h9.546A.75.75 0 0019 10z" clip-rule="evenodd"/>
             </svg>
-            <span>Cerrar Sesión</span>
+            <span class="label">Cerrar Sesión</span>
         </button>
     </nav>
     <main id="content" class="content">


### PR DESCRIPTION
## Summary
- hide logo, menu item labels and logout text when sidebar collapses
- keep elements visible when expanded

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6881553f90988320b805ec593196e18a